### PR TITLE
Rename the C init function

### DIFF
--- a/kubensmnt_linux.go
+++ b/kubensmnt_linux.go
@@ -31,7 +31,7 @@ int nsenterResult = -1;
 char _errorMessage[ERR_LIMIT];
 char* errorMessage = _errorMessage; // Use an intermediary because C.GoString can't work on an array
 
-void __attribute__((constructor)) crio_nsenter_init(int argc, char **argv, char *envp[]) {
+void __attribute__((constructor)) kubensmnt_init() {
 	errorMessage[0] = '\0';
 	nsenterConfig = getKubeNsMnt();
 	nsenterResult = joinMountNamespace(nsenterConfig, errorMessage, ERR_LIMIT);


### PR DESCRIPTION
This is not a functional change, as the name and signature of the
function itself does not matter - But this makes the init function more
portable (not all implementations pass argc/argv/envp to C constructors,
and the rename makes the library look more generic :)

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
