### PR TITLE
Replace awk with bash in kubens.service

### DIFF
--- a/utils/systemd/kubens.service
+++ b/utils/systemd/kubens.service
@@ -16,7 +16,7 @@ ExecStartPre=touch ${BIND_POINT}
 # Use 'unshare' to create the new mountpoint, then 'mount --make-rshared' so it cascades internally
 ExecStart=unshare --mount=${BIND_POINT} --propagation slave mount --make-rshared /
 # Finally, set an env pointer for ease-of-use
-ExecStartPost=awk 'BEGIN {print "KUBENSMNT=${BIND_POINT}" > "${ENVFILE}"}'
+ExecStartPost=bash -c 'echo "KUBENSMNT=${BIND_POINT}" > "${ENVFILE}"'
 
 # On stop, a recursive unmount cleans up the namespace and bind-mounted unbindable parent directory
 ExecStop=umount -R ${RUNTIME_DIRECTORY}


### PR DESCRIPTION
bash is more generally available than awk (awk is NOT part of the core
set of packages in RHEL7, for example), so keep it simple ;)

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
