### PR TITLE
Retool kubensenter to use exec

### DIFF
--- a/utils/kubensenter/kubensenter
+++ b/utils/kubensenter/kubensenter
@@ -81,9 +81,12 @@ kubensenter() {
         # - If $@ is non-empty, nsenter effectively runs `exec "$@"`
         # - If $@ is empty, nsenter spawns a new shell
     fi
+    # Using 'exec' is important here; Without it, systemd may have trouble
+    # seeing the underlying process especially if it's using 'Type=notify'
+    # semantics.
     # shellcheck disable=SC2086
     # ^- Intentionally collapse $nsarg if not set (and we've already shell-quoted it above if we did set it)
-    nsenter $nsarg "$@"
+    exec nsenter $nsarg "$@"
 }
 
 main() {


### PR DESCRIPTION
Especially for cases like kubelet that rely on systemd's Type=notify
mechanism, we don't need or want kubensenter to keep itself in the
process tree.  exec is best.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
