### PR TITLE
check to make sure kubensmnt is mounted

### DIFF
--- a/utils/kubensenter/kubensenter
+++ b/utils/kubensenter/kubensenter
@@ -74,7 +74,13 @@ kubensenter() {
     local nsarg
     if [[ -n $KUBENSMNT ]]; then
         debug "Joining mount namespace in $KUBENSMNT"
-        nsarg=$(printf -- "--mount=%q" "$KUBENSMNT")
+        # make sure $KUBENSMNT is mounted
+        if [[ "$(findmnt --mountpoint="$KUBENSMNT")" ]]; then
+            # assuming $KUBENSMNT propagation is set correctly
+            nsarg=$(printf -- "--mount=%q" "$KUBENSMNT")
+        else
+           info "WARNING: $KUBENSMNT is not mounted; running normally"
+        fi
     else
         debug "KUBENSMNT not set; running normally"
         # Intentional fallthrough to run nsenter anyway:

--- a/utils/kubensenter/test/kubensenter.bats
+++ b/utils/kubensenter/test/kubensenter.bats
@@ -84,3 +84,10 @@ function teardown_file() {
     export DEFAULT_KUBENSMNT="$MOUNT_NAMESPACE"
     run ! kubensenter readlink /proc/self/ns/mnt
 }
+
+@test "Precedence: success when file is not mounted correctly" {
+    touch "$TESTDIR/file_without_mount"
+    export KUBENSMNT="$TESTDIR/file_without_mount"
+    ns=$(kubensenter readlink /proc/self/ns/mnt)
+    [[ "$ns" == "$OLD_NS" ]]
+}


### PR DESCRIPTION
`nsenter` might crash not allow kubelet to start if not properly mounted. e.g `nsenter: reassociate to namespace 'ns/mnt' failed: Invalid argument`

/cc @lack 