### PR TITLE
Pre-create /run/netns bindmount so it propagates to the kubensmnt namespace

### DIFF
--- a/utils/systemd/kubens.service
+++ b/utils/systemd/kubens.service
@@ -18,6 +18,16 @@ ExecStart=unshare --mount=${BIND_POINT} --propagation slave mount --make-rshared
 # Finally, set an env pointer for ease-of-use
 ExecStartPost=bash -c 'echo "KUBENSMNT=${BIND_POINT}" > "${ENVFILE}"'
 
+# Initialize /run/netns as a shared mount point to prevent shadowing race condition
+# This must happen before CRI-O starts to ensure all namespace bind mounts have
+# the correct parent mount. Without this, 'ip netns add' (called later by network
+# components) would create the mount point and shadow any earlier namespace mounts
+# created by CRI-O's pinns, causing pods to fail with 'setns: Invalid argument'.
+# This mirrors the mount setup that 'ip netns add' performs, but does it early.
+# Reference: OCPBUGS-83562
+ExecStartPost=bash -c "mkdir -p /run/netns"
+ExecStartPost=bash -c 'if ! mountpoint -q /run/netns; then mount --bind /run/netns /run/netns && mount --make-shared /run/netns; fi'
+
 # On stop, a recursive unmount cleans up the namespace and bind-mounted unbindable parent directory
 ExecStop=umount -R ${RUNTIME_DIRECTORY}
 


### PR DESCRIPTION
This closes a race between running `ip netns add` inside the kubensmnt
namespace and running it outside of the kubensmnt namespace.

The cause of the race is that the /run/netns/ bindmount created by `ip
netns add` is created with rshared properties, so the external call
would shadow the internal call any time the internal call occurs first.
Forcing the call to happen on the outside ensures any subsequent
internal calls will simply reuse the existing bindmount (as intended).

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
